### PR TITLE
fix: send DST console commands with normal Lua quotes

### DIFF
--- a/src/locales/lang/jp.json
+++ b/src/locales/lang/jp.json
@@ -262,6 +262,11 @@
   "mod.dismiss.button": "今後表示しない",
   "mod.dismiss.success": "アラートを非表示にしました",
 
+  "mod.preference.save": "設定を保存",
+  "mod.preference.save.ok": "Mod設定を保存しました",
+  "mod.preference.save.error": "Mod設定の保存に失敗しました",
+  "mod.preference.no.config": "このModには保存可能な設定がありません",
+
   "backup.BackupList": "バックアップリスト",
   "backup.SnapshotBackup": "スナップショットバックアップ",
   "backup.delete.ok": "バックアップ削除成功",

--- a/src/locales/lang/kr.json
+++ b/src/locales/lang/kr.json
@@ -262,6 +262,11 @@
   "mod.dismiss.button": "다시 표시하지 않음",
   "mod.dismiss.success": "알림이 닫혔습니다",
 
+  "mod.preference.save": "설정 저장",
+  "mod.preference.save.ok": "모드 설정을 저장했습니다",
+  "mod.preference.save.error": "모드 설정 저장 실패",
+  "mod.preference.no.config": "이 모드는 저장할 설정이 없습니다",
+
   "backup.BackupList": "백업 목록",
   "backup.SnapshotBackup": "스냅샷 백업",
   "backup.delete.ok": "백업 삭제 성공",

--- a/src/locales/lang/zh.json
+++ b/src/locales/lang/zh.json
@@ -342,5 +342,6 @@
   "setting.autoGameDown": "宕机恢复",
   "setting.autoModUpdate": "自动mod更新",
   "setting.theme": "主题",
-  "setting.webLinkSetting": "网页链接设置"
+  "setting.webLinkSetting": "网页链接设置",
+  "d": ""
 }

--- a/src/pages/DstData/DstMapData.tsx
+++ b/src/pages/DstData/DstMapData.tsx
@@ -148,7 +148,7 @@ export default () => {
     };
 
     const fetchWasphive = async (cluster: string, levelName: string) =>{
-        await sendCommandApi(cluster, levelName, "c_countprefabs(\\\"wasphive\\\")")
+        await sendCommandApi(cluster, levelName, "c_countprefabs(\"wasphive\")")
         const resp = await readLevelServerLogApi(cluster, levelName, 100)
         if (resp.code === 200) {
             const lines = (resp.data || []) as string[]

--- a/src/pages/Panel/OnlinePlayers/PlayerBtn.jsx
+++ b/src/pages/Panel/OnlinePlayers/PlayerBtn.jsx
@@ -20,7 +20,7 @@ export default ({player, levelName}) => {
     }
 
     const gotoPlayer = (player, otherPlayerKuId) => {
-        let command = `ThePlayer = UserToPlayer(\\"${player.kuId}\\") c_goto(\\"${otherPlayerKuId}\\") ThePlayer = nil`
+        let command = `ThePlayer = UserToPlayer(\"${player.kuId}\") c_goto(\"${otherPlayerKuId}\") ThePlayer = nil`
         sendCommandApi(cluster, levelName, command)
             .then(resp => {
                 if (resp.code === 200) {
@@ -32,7 +32,7 @@ export default ({player, levelName}) => {
     }
 
     const gotoNext = (player, where) => {
-        let command = `ThePlayer = UserToPlayer(\\"${player.kuId}\\") c_gonext(\\"${where}\\") ThePlayer = nil`
+        let command = `ThePlayer = UserToPlayer(\"${player.kuId}\") c_gonext(\"${where}\") ThePlayer = nil`
         sendCommandApi(cluster, levelName, command)
             .then(resp => {
                 if (resp.code === 200) {
@@ -55,7 +55,7 @@ export default ({player, levelName}) => {
     };
 
     const kickPlayer = (player) => {
-        const command = `TheNet:Kick(\\"${player.kuId}\\")`
+        const command = `TheNet:Kick(\"${player.kuId}\")`
         sendCommandApi(cluster, levelName, command)
             .then(resp => {
                 if (resp.code === 200) {
@@ -66,7 +66,7 @@ export default ({player, levelName}) => {
             })
     }
     const killPlayer = (player) => {
-        const command = `UserToPlayer(\\"${player.kuId}\\"):PushEvent('death')`
+        const command = `UserToPlayer(\"${player.kuId}\"):PushEvent('death')`
         sendCommandApi(cluster, levelName, command)
             .then(resp => {
                 if (resp.code === 200) {
@@ -78,7 +78,7 @@ export default ({player, levelName}) => {
     }
     const respawnPlayer = (player) => {
 
-        const command = `UserToPlayer(\\"${player.kuId}\\"):PushEvent('respawnfromghost')`
+        const command = `UserToPlayer(\"${player.kuId}\"):PushEvent('respawnfromghost')`
         sendCommandApi(cluster, levelName, command)
             .then(resp => {
                 if (resp.code === 200) {
@@ -92,9 +92,9 @@ export default ({player, levelName}) => {
     const execPlayerCommand = (player, order, arg) => {
         let command
         if (arg == null) {
-            command = `ThePlayer = UserToPlayer(\\"${player.kuId}\\") ${order}() ThePlayer = nil`
+            command = `ThePlayer = UserToPlayer(\"${player.kuId}\") ${order}() ThePlayer = nil`
         } else {
-            command = `ThePlayer = UserToPlayer(\\"${player.kuId}\\") ${order}(${arg}) ThePlayer = nil`
+            command = `ThePlayer = UserToPlayer(\"${player.kuId}\") ${order}(${arg}) ThePlayer = nil`
         }
         sendCommandApi(cluster, levelName, command)
             .then(resp => {
@@ -107,7 +107,7 @@ export default ({player, levelName}) => {
     }
 
     const despawnPlayer = (player) => {
-        const command = `c_despawn(\\"${player.kuId}\\")`
+        const command = `c_despawn(\"${player.kuId}\")`
         sendCommandApi(cluster, levelName, command)
             .then(resp => {
                 if (resp.code === 200) {
@@ -119,7 +119,7 @@ export default ({player, levelName}) => {
     }
 
     const resetskilltree = (player) => {
-        const command = `ThePlayer = UserToPlayer(\\"${player.kuId}\\") require(\\"debugcommands\\") d_resetskilltree() ThePlayer = nil`
+        const command = `ThePlayer = UserToPlayer(\"${player.kuId}\") require(\"debugcommands\") d_resetskilltree() ThePlayer = nil`
         sendCommandApi(cluster, levelName, command)
             .then(resp => {
                 if (resp.code === 200) {

--- a/src/pages/Panel/OnlinePlayers/PlayerDetailDrawer.jsx
+++ b/src/pages/Panel/OnlinePlayers/PlayerDetailDrawer.jsx
@@ -129,7 +129,7 @@ export default ({player, visible, onClose, levelName}) => {
                 // 注意：模板字符串中的转义字符可能需要根据实际语言环境调整
                 // 原代码: GetPlayerData(\"${player.kuId}\", \"${uuid}\")
                 // 如果这是发送给 Lua/特定脚本引擎的命令，请确保引号转义正确
-                const command = `print(ToJSONStr(GetPlayerData(\\"${player.kuId}\\", \\"${uuid}\\")))`;
+                const command = `print(ToJSONStr(GetPlayerData(\"${player.kuId}\", \"${uuid}\")))`;
 
                 const commandResp = await sendCommandApi(cluster, levelName, command);
 

--- a/src/pages/Panel/RemoteControl/index.jsx
+++ b/src/pages/Panel/RemoteControl/index.jsx
@@ -61,7 +61,7 @@ export default () => {
         console.log(levelName, command)
         setSpin(true)
         addHistory(command)
-        sendCommandApi("", levelName, escapeString(command))
+        sendCommandApi("", levelName, command)
             .then(resp => {
                 if (resp.code === 200) {
                     message.success("发送指令成功")
@@ -81,7 +81,7 @@ export default () => {
         setSpin(true)
         const cmd = `c_announce"${command2}"`
         addHistory(command2)
-        sendCommandApi("", levelName, escapeString(cmd))
+        sendCommandApi("", levelName, cmd)
             .then(resp => {
                 if (resp.code === 200) {
                     message.success("发送指令成功")
@@ -90,15 +90,6 @@ export default () => {
                 }
                 setSpin(false)
             })
-    }
-
-    function escapeString(str) {
-        return str.replace(/\\/g, '\\\\')
-            .replace(/"/g, '\\"')
-            .replace(/'/g, "\\'")
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r')
-            .replace(/\t/g, '\\t');
     }
 
     const handleChange = (value) => {

--- a/src/pages/Panel/ServerLog/index.jsx
+++ b/src/pages/Panel/ServerLog/index.jsx
@@ -46,29 +46,6 @@ const RollbackButtons = ({onRollback, t}) => {
     );
 };
 
-const formatRuntime = (totalSeconds) => {
-    if (!Number.isFinite(totalSeconds)) return "未知"
-    const seconds = Math.max(0, Math.floor(totalSeconds))
-    const hours = Math.floor(seconds / 3600)
-    const minutes = Math.floor((seconds % 3600) / 60)
-    const remainSeconds = seconds % 60
-    const pad = (value) => String(value).padStart(2, '0')
-    return `${pad(hours)}:${pad(minutes)}:${pad(remainSeconds)}`
-}
-
-const extractLatestRuntimeSeconds = (lines) => {
-    let latest = null
-    lines.forEach(line => {
-        const match = /^\[(\d+):(\d+):(\d+)\]/.exec(line)
-        if (!match) return
-        const totalSeconds = Number(match[1]) * 3600 + Number(match[2]) * 60 + Number(match[3])
-        if (latest === null || totalSeconds > latest) {
-            latest = totalSeconds
-        }
-    })
-    return latest
-}
-
 export default () => {
     const {t} = useTranslation()
     const {theme} = useTheme();
@@ -84,7 +61,6 @@ export default () => {
     }, [levels, notHasLevels])
     const [currentLevelName, setCurrentLevelName] = useState(defaultLevelName)
     const editorRef = useRef()
-    const [runtimeSeconds, setRuntimeSeconds] = useState(null)
     const currentLevel = useMemo(() => levels.find(level => level.key === currentLevelName), [levels, currentLevelName])
     const processElapsed = currentLevel?.Ps?.elapsed || currentLevel?.ps?.elapsed
 
@@ -101,23 +77,13 @@ export default () => {
         setCommand(e.target.value);
     };
 
-    function escapeString(str) {
-        return str.replace(/\\/g, '\\\\')
-            .replace(/"/g, '\\"')
-            .replace(/'/g, "\\'")
-            .replace(/\n/g, '\\n')
-            .replace(/\r/g, '\\r')
-            .replace(/\t/g, '\\t');
-    }
-
     function sendInstruct(command) {
         if (command === "") {
             message.warning("请填写指令在发送")
             return
         }
-        console.log(currentLevelName, escapeString(command))
         setSpinLoading(true)
-        sendCommandApi(cluster, currentLevelName, escapeString(command))
+        sendCommandApi(cluster, currentLevelName, command)
             .then(resp => {
                 if (resp.code === 200) {
                     message.success("发送指令成功")
@@ -136,10 +102,6 @@ export default () => {
             const currentLogs = editorRef?.current?.current?.getValue() || ""
             editorRef?.current?.current?.setValue(currentLogs + `${line}\n`)
             editorRef?.current?.current?.revealLine(editorRef?.current?.current?.getModel()?.getLineCount())
-            const latestRuntime = extractLatestRuntimeSeconds([line])
-            if (latestRuntime !== null) {
-                setRuntimeSeconds(latestRuntime)
-            }
         },
         onError: (err) => {
             console.error('Log stream error:', err)
@@ -151,7 +113,6 @@ export default () => {
 
     const handleChange = (value) => {
         setCurrentLevelName(value)
-        setRuntimeSeconds(null)
         editorRef?.current?.current?.setValue("")
     }
 
@@ -185,7 +146,7 @@ export default () => {
                 </Space>}
             >
                 <Typography.Text type="secondary" style={{display: 'block', marginBottom: 12}}>
-                    日志行首的 [HH:MM:SS] 是 DST 分片进程启动后的日志相对时间，不是系统时间；进程运行时长：{processElapsed || '未运行/未知'}；日志最新时间：{formatRuntime(runtimeSeconds)}
+                    日志行首的 [HH:MM:SS] 是 DST 分片进程启动后的日志相对时间，不是系统时间；进程运行时长：{processElapsed || '未运行/未知'}
                 </Typography.Text>
                 <MonacoEditor
                     className={style.icon}

--- a/src/pages/TooManyItemsPlus/ItemsList.tsx
+++ b/src/pages/TooManyItemsPlus/ItemsList.tsx
@@ -17,7 +17,7 @@ export default function ItemList(itemListProps: ItemListProps) {
     function give(levelName: string, prefab: string, amount: number, kuId: string) {
         setLoadingItems(prev => new Set(prev).add(prefab));
 
-        const command = `ThePlayer = UserToPlayer(\\"${kuId}\\")   c_give(\\"${prefab}\\", ${amount}) ThePlayer = nil`
+        const command = `ThePlayer = UserToPlayer(\"${kuId}\")   c_give(\"${prefab}\", ${amount}) ThePlayer = nil`
         sendCommandApi(cluster || "", levelName, command)
             .then(resp => {
                 if (resp.code === 200) {

--- a/src/pages/TooManyItemsPlus/OtherIOrder.tsx
+++ b/src/pages/TooManyItemsPlus/OtherIOrder.tsx
@@ -31,7 +31,7 @@ export default function OtherIOrder(){
     const [levelName, setLevelName] = useState(notHasLevels?"":levels[0].key)
 
     function give(prefab: string, amount: number, kuId: string) {
-        const command = `ThePlayer = UserToPlayer(\\"${kuId}\\")   c_give(\\"${prefab}\\", ${amount}) ThePlayer = nil`
+        const command = `ThePlayer = UserToPlayer(\"${kuId}\")   c_give(\"${prefab}\", ${amount}) ThePlayer = nil`
         sendCommandApi(cluster || "", levelName, command)
             .then(resp =>{
                 if (resp.code === 200) {
@@ -48,24 +48,24 @@ export default function OtherIOrder(){
                 时间按钮
             </Typography.Title>
             <Space wrap size={16}>
-                <Button type={'primary'} onClick={() => send('TheWorld:PushEvent(\\"ms_nextcycle\\")')}>跳过一天</Button>
-                <Button type={'primary'} onClick={() => send('TheWorld:PushEvent(\\"ms_nextphase\\")')}>跳过时钟</Button>
+                <Button type={'primary'} onClick={() => send('TheWorld:PushEvent(\"ms_nextcycle\")')}>跳过一天</Button>
+                <Button type={'primary'} onClick={() => send('TheWorld:PushEvent(\"ms_nextphase\")')}>跳过时钟</Button>
                 <Button type={'primary'}
-                        onClick={() => send('TheWorld:PushEvent(\\"ms_setseason\\", \\"summer\\")')}>进入夏季</Button>
+                        onClick={() => send('TheWorld:PushEvent(\"ms_setseason\", \"summer\")')}>进入夏季</Button>
                 <Button type={'primary'}
-                        onClick={() => send('TheWorld:PushEvent(\\"ms_setseason\\", \\"winter\\")')}>进入冬季</Button>
+                        onClick={() => send('TheWorld:PushEvent(\"ms_setseason\", \"winter\")')}>进入冬季</Button>
                 <Button type={'primary'}
-                        onClick={() => send('TheWorld:PushEvent(\\"ms_setseason\\", \\"spring\\")')}>进入春季</Button>
+                        onClick={() => send('TheWorld:PushEvent(\"ms_setseason\", \"spring\")')}>进入春季</Button>
                 <Button type={'primary'}
-                        onClick={() => send('TheWorld:PushEvent(\\"ms_setseason\\", \\"autumn\\")')}>进人秋季</Button>
+                        onClick={() => send('TheWorld:PushEvent(\"ms_setseason\", \"autumn\")')}>进人秋季</Button>
                 <Button type={'primary'}
-                        onClick={() => send('TheWorld:PushEvent(\\"ms_forceprecipitation\\")')}>开始下雨</Button>
+                        onClick={() => send('TheWorld:PushEvent(\"ms_forceprecipitation\")')}>开始下雨</Button>
                 <Button type={'primary'}
-                        onClick={() => send('TheWorld:PushEvent(\\"ms_forceprecipitation\\", false)')}>停止下雨</Button>
+                        onClick={() => send('TheWorld:PushEvent(\"ms_forceprecipitation\", false)')}>停止下雨</Button>
                 <Button type={'primary'}
-                        onClick={() => send('TheWorld:PushEvent(\\"ms_startthemoonstorms\\")')}>开启月亮裂隙</Button>
+                        onClick={() => send('TheWorld:PushEvent(\"ms_startthemoonstorms\")')}>开启月亮裂隙</Button>
                 <Button type={'primary'}
-                        onClick={() => send('TheWorld:PushEvent(\\"ms_stopthemoonstorms\\")')}>关闭月亮裂隙</Button>
+                        onClick={() => send('TheWorld:PushEvent(\"ms_stopthemoonstorms\")')}>关闭月亮裂隙</Button>
             </Space>
             <Divider />
             <Typography.Title level={5}>


### PR DESCRIPTION
## Summary

Frontend companion fix for carrot-hu23/dst-admin-go#164.

The backend fix preserves Lua command quotes by bypassing shell parsing. This web change removes the old shell-escaping assumptions from UI-generated command strings so the browser sends normal Lua source code to the backend.

Also removes the misleading server-log status text requested during testing:

- `日志最新时间：未知`

## Changes

- Send manual Server Log panel commands as raw command text instead of pre-escaping quotes/backslashes.
- Send Remote Control panel commands as raw command text instead of pre-escaping quotes/backslashes.
- Update TooManyItemsPlus item grants and time/weather buttons to generate normal Lua quotes.
- Update online-player action commands and map helper command generation to generate normal Lua quotes.
- Remove the `日志最新时间` display and the associated runtime parsing state from the server log page.
- Fill missing locale keys for all configured UI languages (`zh`, `en`, `jp`, `kr`) so the locale key sets are aligned.

## Why

Previously many UI commands generated shell-escaped text like:

```lua
c_give(\"goldnugget\", 3)
```

That only worked accidentally when the backend wrapped the command in `sh -c`, because the shell stripped those backslashes. With the backend correctly preserving argv text, the frontend must send actual Lua command text:

```lua
c_give("goldnugget", 3)
```

## Compatibility / language check

- Checked every `sendCommandApi` command generator that used escaped quotes and converted them to normal Lua command strings.
- Verified all configured frontend locale files have matching keys:
  - `en`: 302 keys, 0 missing
  - `zh`: 302 keys, 0 missing
  - `jp`: 302 keys, 0 missing
  - `kr`: 302 keys, 0 missing
- No new UI text was added for the quote fix; the only text removal is the requested `日志最新时间：未知` area.

## Test plan

Automated:

- Locale key parity script across `src/locales/lang/*.json`
- `npm run build`

Manual / live DST verification from paired backend testing:

- Confirmed quoted commands now arrive in `server_log.txt` with quotes preserved.
- Confirmed `c_give("goldnugget", 3)` grants three gold nuggets to the target online player.
- This verifies the path used by TooManyItemsPlus-style player-targeted item grants.

Related backend PR: https://github.com/carrot-hu23/dst-admin-go/pull/167
